### PR TITLE
feature/ordenar-pagos-filtro-clientes-agrupar-por-dia

### DIFF
--- a/app/Filament/Resources/CustomerResource.php
+++ b/app/Filament/Resources/CustomerResource.php
@@ -101,7 +101,15 @@ class CustomerResource extends Resource
                     ->icon(fn ($state) => CustomerStatusEnum::from($state)->getIcon()), 
             ])
             ->filters([
-                //
+                Tables\Filters\SelectFilter::make('status')
+                    ->label(__('messages.customer.status_customer'))
+                    ->options([
+                        CustomerStatusEnum::UNKNOWN->value => __('messages.customer.status_unknown'),
+                        CustomerStatusEnum::BAD->value => __('messages.customer.status_bad'),
+                        CustomerStatusEnum::GOOD->value => __('messages.customer.status_good'),
+                        CustomerStatusEnum::EXCELLENT->value => __('messages.customer.status_excellent'),
+                    ])
+                    ->default(CustomerStatusEnum::UNKNOWN->value),
             ])
             ->actions([
                 Tables\Actions\ActionGroup::make([

--- a/resources/views/printer/orderpayments.blade.php
+++ b/resources/views/printer/orderpayments.blade.php
@@ -99,7 +99,7 @@
 
         <div class="row totals">
             @php
-                $orderPayments = $order->payments->sortByDesc('created_at');
+                $orderPayments = $order->payments->sortBy('created_at');
                 
                 $firstPayment = $orderPayments->first();
 


### PR DESCRIPTION
- Se ordenaron los pagos de manera descendente al momento de imprimir
- Se agregó el filtro en clientes
- Se agruparon los pagos en el reporte de pagos por día.